### PR TITLE
allow LoadDecryptionKey to take a byte array

### DIFF
--- a/Mastercard.Developer.ClientEncryption.Core/Utils/EncryptionUtils.cs
+++ b/Mastercard.Developer.ClientEncryption.Core/Utils/EncryptionUtils.cs
@@ -33,5 +33,13 @@ namespace Mastercard.Developer.ClientEncryption.Core.Utils
             var certificate = new X509Certificate2(pkcs12KeyFilePath, decryptionKeyPassword, keyStorageFlags);
             return certificate.GetRSAPrivateKey();
         }
+
+        /// <summary>
+        /// Load a RSA decryption key from a byte array.
+        /// </summary>
+        public static RSA LoadDecryptionKey(byte[] key)
+        {
+            return RsaKeyUtils.ReadPrivateKey(key);
+        }
     }
 }

--- a/Mastercard.Developer.ClientEncryption.Core/Utils/RsaKeyUtils.cs
+++ b/Mastercard.Developer.ClientEncryption.Core/Utils/RsaKeyUtils.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 
 namespace Mastercard.Developer.ClientEncryption.Core.Utils
 {
@@ -16,7 +17,13 @@ namespace Mastercard.Developer.ClientEncryption.Core.Utils
         internal static RSA ReadPrivateKeyFile(string keyFilePath)
         {
             if (keyFilePath == null) throw new ArgumentNullException(nameof(keyFilePath));
-            var keyString = File.ReadAllText(keyFilePath);
+            var key = File.ReadAllBytes(keyFilePath);
+            return ReadPrivateKey(key);
+        }
+        
+        internal static RSA ReadPrivateKey(byte[] key)
+        {
+            var keyString = Encoding.UTF8.GetString(key);
             if (keyString.Contains(Pkcs1PemHeader))
             {
                 // OpenSSL / PKCS#1 Base64 PEM encoded file
@@ -34,9 +41,7 @@ namespace Mastercard.Developer.ClientEncryption.Core.Utils
                 keyString = keyString.Replace(Environment.NewLine, string.Empty);
                 return ReadPkcs8Key(Convert.FromBase64String(keyString));
             }
-
-            // We assume it's a PKCS#8 DER encoded binary file
-            return ReadPkcs8Key(File.ReadAllBytes(keyFilePath));
+            return ReadPkcs8Key(key);
         }
 
         private static RSA ReadPkcs8Key(byte[] pkcs8Bytes)
@@ -269,5 +274,7 @@ namespace Mastercard.Developer.ClientEncryption.Core.Utils
             reader.BaseStream.Seek(-1, SeekOrigin.Current);
             return size;
         }
+
+        
     }
 }

--- a/Mastercard.Developer.ClientEncryption.Tests/NetCore2/Utils/RsaKeyUtilsTest.cs
+++ b/Mastercard.Developer.ClientEncryption.Tests/NetCore2/Utils/RsaKeyUtilsTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Mastercard.Developer.ClientEncryption.Core.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -7,172 +8,53 @@ namespace Mastercard.Developer.ClientEncryption.Tests.NetCore.Utils
     [TestClass]
     public class RsaKeyUtilsTest
     {
+        
         [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Pem512bits()
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-512.pem", 512)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-1024.pem", 1024)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-2048.pem", 2048)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-4096.pem", 4096)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-512.der", 512)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-1024.der", 1024)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-2048.der", 2048)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-4096.der", 4096)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-512.pem", 512)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-1024.pem", 1024)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-2048.pem", 2048)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-4096.pem", 4096)]
+        public void TestReadPrivateKeyFile(string keyPath, int expectedKeySize)
         {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-512.pem";
-
             // WHEN
             var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
 
             // THEN
             Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name); // We expect a RSACng (Windows) or a RSAOpenSsl (Linux, macOS)
-            Assert.AreEqual(512, rsa.KeySize);
+            Assert.AreEqual(expectedKeySize, rsa.KeySize);
         }
-
+        
         [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Pem1024bits()
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-512.pem", 512)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-1024.pem", 1024)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-2048.pem", 2048)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-4096.pem", 4096)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-512.der", 512)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-1024.der", 1024)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-2048.der", 2048)]
+        [DataRow("./_Resources/Keys/Pkcs8/test_key_pkcs8-4096.der", 4096)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-512.pem", 512)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-1024.pem", 1024)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-2048.pem", 2048)]
+        [DataRow("./_Resources/Keys/Pkcs1/test_key_pkcs1-4096.pem", 4096)]
+        public void TestReadPrivateKey(string keyPath, int expectedKeySize)
         {
             // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-1024.pem";
-
+            var bytes = File.ReadAllBytes(keyPath);
             // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
+            var rsa = RsaKeyUtils.ReadPrivateKey(bytes);
 
             // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(1024, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Pem2048bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-2048.pem";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(2048, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Pem4096bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-4096.pem";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(4096, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Der512bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-512.der";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(512, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Der1024bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-1024.der";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(1024, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Der2048bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-2048.der";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(2048, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs8Der4096bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs8/test_key_pkcs8-4096.der";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(4096, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs1Base64Pem512bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs1/test_key_pkcs1-512.pem";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(512, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs1Base64Pem1024bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs1/test_key_pkcs1-1024.pem";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(1024, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs1Base64Pem2048bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs1/test_key_pkcs1-2048.pem";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(2048, rsa.KeySize);
-        }
-
-        [TestMethod]
-        public void TestReadPrivateKeyFile_ShouldSupportPkcs1Base64Pem4096bits()
-        {
-            // GIVEN
-            const string keyPath = "./_Resources/Keys/Pkcs1/test_key_pkcs1-4096.pem";
-
-            // WHEN
-            var rsa = RsaKeyUtils.ReadPrivateKeyFile(keyPath);
-
-            // THEN
-            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name);
-            Assert.AreEqual(4096, rsa.KeySize);
+            Assert.AreNotEqual("RSACryptoServiceProvider", rsa.GetType().Name); // We expect a RSACng (Windows) or a RSAOpenSsl (Linux, macOS)
+            Assert.AreEqual(expectedKeySize, rsa.KeySize);
         }
 
         [TestMethod]


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [X] An issue/feature request has been created for this PR
- [X] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [X] File the PR against the `master` branch
- [X] The code in this PR is covered by unit tests

#### Link to issue/feature request: https://github.com/Mastercard/client-encryption-csharp/issues/11

#### Description
adding a third signature EncryptionUtils.LoadDecryptionKey

I parametrized the tests for readability, and added the same test case data as the original file-based LoadDecryptionKey
