### PR TITLE
Fix: sonar issue: csharpsquid:S6444. Denial of Service security hotspot

### DIFF
--- a/Mastercard.Developer.ClientEncryption.Core/Utils/JsonUtils.cs
+++ b/Mastercard.Developer.ClientEncryption.Core/Utils/JsonUtils.cs
@@ -7,7 +7,7 @@ namespace Mastercard.Developer.ClientEncryption.Core.Utils
 {
     internal static class JsonUtils
     {
-        private static readonly Regex LastElementInPathRegExp = new Regex(".*(\\['.*'\\])"); // Returns "['obj2']" for "$['obj1']['obj2']"
+        private static readonly Regex LastElementInPathRegExp = new Regex(".*(\\['.*'\\])", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100)); // Returns "['obj2']" for "$['obj1']['obj2']"
         
         /// <summary>
         /// Get JSON path to the parent of the object at the given JSON path.


### PR DESCRIPTION
Fix: sonar issue: csharpsquid:S6444. Denial of Service - Pass a timeout to limit the execution time. [Issue Link](https://sonarcloud.io/organizations/mastercard/rules?open=csharpsquid%3AS6444&rule_key=csharpsquid%3AS6444)